### PR TITLE
Add file permission hint for recursive flag.

### DIFF
--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -58,6 +58,7 @@ options:
   recurse:
     description:
     - Recursively set the specified file attributes on directory contents.
+    - Given file permissions will apply to subdirectories only. 
     - This applies only when C(state) is set to C(directory).
     type: bool
     default: no

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -58,8 +58,8 @@ options:
   recurse:
     description:
     - Recursively set the specified file attributes on directory contents.
-    - Given file permissions will apply to subdirectories only. 
     - This applies only when C(state) is set to C(directory).
+    - Given file permissions will apply to subdirectories only.
     type: bool
     default: no
     version_added: '1.1'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When using the file module in ansible, it is very confusing when you write something like this:
```
---
  - name: My playbook that changes file permissions
    hosts: localhost
    become: true
    pre_tasks:
      - name: Add executable permissions to subdirectory files
        file:
          path: "/opt/somedir/bin"
          mode: "a=rX"
          recurse: yes
          state: directory
          owner: me
          group: me
```

and expect that the given directory will change from this:

```
~/projects/delete_me$ ls -lisa /opt/somedir/bin
total 32
dr--r--r--  3 me me   4096 Mar 29 10:18 ./
drwxr-xr-x 21 me www-data 4096 Mar 29 09:33 ../
dr--r--r--  2 me me   4096 Mar 29 10:18 change_me/
-r--r--r--  1 me me   1151 Mar 29 09:33 check
-r--r--r--  1 me me    817 Mar 29 09:33 check-slim
-r--r--r--  1 me me    204 Mar 29 09:33 code-style
-r--r--r--  1 me me   1202 Mar 29 09:33 console
-r--r--r--  1 me me    659 Mar 29 09:33 phpunit
```

to this


```
~/projects/delete_me$ ls -lisa /opt/somedir/bin
total 32
dr-xr-xr-x  3 me me   4096 Mar 29 10:18 ./
drwxr-xr-x 21 me www-data 4096 Mar 29 09:33 ../
dr-xr-xr-x  2 me me   4096 Mar 29 10:18 change_me/
-r-xr-xr-x  1 me me   1151 Mar 29 09:33 check
-r-xr-xr-x  1 me me    817 Mar 29 09:33 check-slim
-r-xr-xr-x  1 me me    204 Mar 29 09:33 code-style
-r-xr-xr-x  1 me me   1202 Mar 29 09:33 console
-r-xr-xr-x  1 me me    659 Mar 29 09:33 phpunit
```

The actual behavior of the file module is this:

```
~/projects/delete_me$ ls -lisa /opt/somedir/bin
total 32
dr-xr-xr-x  3 me me   4096 Mar 29 10:18 ./
drwxr-xr-x 21 me www-data 4096 Mar 29 09:33 ../
dr-xr-xr-x  2 me me   4096 Mar 29 10:18 change_me/
-r--r--r--  1 me me   1151 Mar 29 09:33 check
-r--r--r--  1 me me    817 Mar 29 09:33 check-slim
-r--r--r--  1 me me    204 Mar 29 09:33 code-style
-r--r--r--  1 me me   1202 Mar 29 09:33 console
-r--r--r--  1 me me    659 Mar 29 09:33 phpunit
```

It will only apply permission changes to subdirectories and not files. So if you specify "recurse: yes" in the playbook, not all file attributes will be populated recursively. This is very counterintuitive and it is not mentioned anywhere in the docs directly. Therefore I propose these changes to clarify the usage of this module for any users. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
file

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
